### PR TITLE
Add Transport Interface Implementation for IntelPage Module

### DIFF
--- a/webservice/src/Core/IntelPage/Application/IntelPageTransport.php
+++ b/webservice/src/Core/IntelPage/Application/IntelPageTransport.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\CommandBus;
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Bus\QueryBus;
+use App\Core\IntelPage\Command\QueueMessage;
+use App\Core\IntelPage\Exception\IntelPageMessageTooLong;
+use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\Pager;
+use App\Core\IntelPage\Model\PagerMessage;
+use App\Core\IntelPage\Model\RecipientConfiguration;
+use App\Core\IntelPage\Query\ChannelCapCodeById;
+use App\Core\IntelPage\Query\PagerByRecipient;
+use App\Core\TransportContract\Model\Message;
+use App\Core\TransportContract\Model\MessageRecipient;
+use App\Core\TransportContract\Model\OutgoingMessage;
+use App\Core\TransportContract\Model\OutgoingMessageEvent;
+use App\Core\TransportContract\Model\Priority;
+use App\Core\TransportContract\Model\SystemTransportConfig;
+use App\Core\TransportContract\Port\Transport;
+use function strlen;
+
+/**
+ * Queues a message to be sent through an IntelPage appliance to hardware
+ * pager based on the recipient & pager configuration.
+ *
+ * @internal responsibility of the class itself is to find the right cap code,
+ * everything else is delegated
+ */
+final readonly class IntelPageTransport implements Transport
+{
+    public function __construct(
+        private SystemTransportConfig $config,
+        private QueryBus $queryBus,
+        private CommandBus $commandBus,
+        private EventBus $eventBus,
+    ) {
+    }
+
+    public function key(): string
+    {
+        return $this->config->getKey();
+    }
+
+    public function acceptsNewMessages(): bool
+    {
+        /* At this time, there is no option to configure the transport from
+         * the application side. It is to be expected, that the operations
+         * responsible configured the transport correctly, therefore (for now)
+         * this method always returns true.
+         */
+        return true;
+    }
+
+    public function canSendTo(MessageRecipient $recipient, Message $incomingMessage): bool
+    {
+        $this->validateMessageLength($incomingMessage->body);
+
+        $config = $recipient->getTransportConfigurationFor($this);
+        if (null === $config) {
+            return false;
+        }
+        $recipientConfiguration = new RecipientConfiguration($config);
+
+        if ($recipientConfiguration->hasChannelConfiguration()) {
+            // -- should send to channel, can do so only if channel cap code was found in database:
+            return $this->channelCapCode($recipientConfiguration) instanceof CapCode;
+        }
+
+        // -- should send to individual pager
+        $pager = $this->getPager($recipient);
+
+        return $pager instanceof Pager // can send only if pager was found
+            && $pager->isActivated()  //  and pager is active
+            && $this->selectPagerCapBasedOnPriority(
+                $incomingMessage->priority, $recipientConfiguration, $pager
+            ) instanceof CapCode; // and cap code was assigned to pager
+    }
+
+    public function send(OutgoingMessage $message): void
+    {
+        $capCode = $this->tryToRetrieveCapCode($message);
+        if (!$capCode instanceof CapCode) {
+            // -- this should never happen, reasons to land here:
+            //    a) something changed between calls ::canSendTo() and ::send()
+            //    b) developer failed to make all relevant checks in ::canSendTo()
+            $this->failedToSend($message);
+
+            return;
+        }
+
+        $this->commandBus->do(QueueMessage::with(
+            $message->id,
+            $capCode,
+            $message->incomingMessage->body,
+            $message->incomingMessage->priority->value,
+            $message->incomingMessage->messageId,
+        ));
+    }
+
+    private function tryToRetrieveCapCode(OutgoingMessage $message): ?CapCode
+    {
+        $config = $message->recipient->getTransportConfigurationFor($this);
+        if (null === $config) {
+            return null;
+        }
+        $recipientConfiguration = new RecipientConfiguration($config);
+
+        if ($recipientConfiguration->hasChannelConfiguration()) {
+            return $this->channelCapCode($recipientConfiguration);
+        }
+
+        $pager = $this->getPager($message->recipient);
+
+        return $pager instanceof Pager ? $this->selectPagerCapBasedOnPriority($message->incomingMessage->priority, $recipientConfiguration, $pager) : null;
+    }
+
+    private function getPager(MessageRecipient $recipient): ?Pager
+    {
+        return $this->queryBus->get(PagerByRecipient::withId($recipient->getId()->toString()));
+    }
+
+    private function validateMessageLength(string $messageString): void
+    {
+        if (($len = strlen($messageString)) > PagerMessage::MAX_LENGTH) {
+            throw IntelPageMessageTooLong::withLength($len);
+        }
+    }
+
+    public function channelCapCode(RecipientConfiguration $recipientConfiguration): ?CapCode
+    {
+        return $this->queryBus->get(new ChannelCapCodeById($recipientConfiguration->channelId()));
+    }
+
+    private function selectPagerCapBasedOnPriority(
+        Priority $messagePriority, RecipientConfiguration $recipientConfiguration, Pager $pager,
+    ): ?CapCode {
+        if ($messagePriority->isHigherOrEqual($recipientConfiguration->alertFromPriority())) {
+            return $pager->individualAlertCap();
+        }
+
+        return $pager->individualNonAlertCap();
+    }
+
+    /**
+     * Publish failure event to EventBus.
+     *
+     * @see OutgoingMessageEvent
+     */
+    private function failedToSend(OutgoingMessage $message): void
+    {
+        $this->eventBus->publish(OutgoingMessageEvent::failedToQueue($message->id, $message->incomingMessage->messageId));
+    }
+}

--- a/webservice/src/Core/IntelPage/Application/IntelPageTransportFactory.php
+++ b/webservice/src/Core/IntelPage/Application/IntelPageTransportFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\CommandBus;
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Bus\QueryBus;
+use App\Core\TransportContract\Model\SystemTransportConfig;
+
+/**
+ * The factory combines services from dependency injection with the individual configuration.
+ */
+final readonly class IntelPageTransportFactory implements \App\Core\TransportContract\Port\TransportFactory\IntelPageTransportFactory
+{
+    public function __construct(
+        private QueryBus $queryBus,
+        private CommandBus $commandBus,
+        private EventBus $eventBus,
+    ) {
+    }
+
+    public function withSystemConfiguration(SystemTransportConfig $config): IntelPageTransport
+    {
+        return new IntelPageTransport(
+            $config,
+            $this->queryBus,
+            $this->commandBus,
+            $this->eventBus,
+        );
+    }
+}

--- a/webservice/src/Core/IntelPage/Application/QueueMessageHandler.php
+++ b/webservice/src/Core/IntelPage/Application/QueueMessageHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Persistence\UnitOfWork;
+use App\Core\IntelPage\Command\QueueMessage;
+use App\Core\IntelPage\Model\PagerMessage;
+use App\Core\IntelPage\Port\PagerMessageRepository;
+use App\Core\TransportContract\Model\OutgoingMessageEvent;
+
+final readonly class QueueMessageHandler
+{
+    public function __construct(
+        private PagerMessageRepository $pagerMessageRepository,
+        private UnitOfWork $uow,
+        private EventBus $eventBus,
+    ) {
+    }
+
+    public function __invoke(QueueMessage $cmd): void
+    {
+        $pagerMessage = PagerMessage::new($cmd->id, $cmd->capCode, $cmd->message, $cmd->priority);
+        $this->pagerMessageRepository->add($pagerMessage);
+        $this->uow->commit();
+
+        $this->eventBus->publish(OutgoingMessageEvent::queued($cmd->incomingMessageId, $cmd->id));
+    }
+}

--- a/webservice/src/Core/IntelPage/Command/QueueMessage.php
+++ b/webservice/src/Core/IntelPage/Command/QueueMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Command;
+
+use App\Core\IntelPage\Model\CapCode;
+use Symfony\Component\Uid\Ulid;
+
+readonly class QueueMessage
+{
+    public static function with(
+        Ulid $id,
+        CapCode $capCode,
+        string $message,
+        int $priority,
+        Ulid $incomingMessageId,
+    ): self {
+        return new self($id, $capCode, $message, $priority, $incomingMessageId);
+    }
+
+    public function __construct(
+        public Ulid $id,
+        public CapCode $capCode,
+        public string $message,
+        public int $priority,
+        public Ulid $incomingMessageId,
+    ) {
+    }
+}

--- a/webservice/src/Core/IntelPage/Exception/IntelPageMessageTooLong.php
+++ b/webservice/src/Core/IntelPage/Exception/IntelPageMessageTooLong.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Exception;
+
+use RuntimeException;
+use function sprintf;
+
+final class IntelPageMessageTooLong extends RuntimeException
+{
+    public static function withLength(int $length): self
+    {
+        return new self(sprintf('The message was too long with %d Bytes, the maximum allowed is 512.', $length));
+    }
+}

--- a/webservice/src/Core/IntelPage/Model/PagerMessage.php
+++ b/webservice/src/Core/IntelPage/Model/PagerMessage.php
@@ -11,6 +11,8 @@ use Symfony\Component\Uid\Ulid;
 #[ORM\Entity]
 class PagerMessage
 {
+    public const int MAX_LENGTH = 512;
+
     #[ORM\Id]
     #[ORM\Column(type: 'ulid')]
     private readonly Ulid $id;
@@ -18,7 +20,7 @@ class PagerMessage
     #[ORM\Embedded]
     private readonly CapCode $cap;
 
-    #[ORM\Column(length: 512)]
+    #[ORM\Column(length: self::MAX_LENGTH)]
     private readonly string $message;
 
     #[ORM\Column(type: 'instant')]
@@ -35,6 +37,10 @@ class PagerMessage
 
     public static function new(Ulid $id, CapCode $cap, string $message, int $priority): self
     {
+        if (str_contains($message, "\r")) {
+            $message = str_replace("\r", ' ', $message);
+        }
+
         return new self(
             $id,
             $cap,

--- a/webservice/src/Core/IntelPage/Model/RecipientConfiguration.php
+++ b/webservice/src/Core/IntelPage/Model/RecipientConfiguration.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Model;
+
+use App\Core\TransportContract\Model\Priority;
+use function array_key_exists;
+
+/**
+ * @todo TEST
+ */
+final readonly class RecipientConfiguration
+{
+    public const Priority DEFAULT_ALERT_FROM_PRIORITY = Priority::HIGH;
+    public const string KEY_CHANNEL = 'channel';
+    public const string KEY_ALERT_FROM_PRIORITY = 'alert_from_priority';
+
+    // @phpstan-ignore-next-line missingType.iterableValue (JSON compatible array)
+    public function __construct(public array $config)
+    {
+    }
+
+    public function hasChannelConfiguration(): bool
+    {
+        return array_key_exists(self::KEY_CHANNEL, $this->config);
+    }
+
+    public function channelId(): string
+    {
+        return $this->config[self::KEY_CHANNEL];
+    }
+
+    public function alertFromPriority(): Priority
+    {
+        return Priority::tryFrom(
+            $this->config[self::KEY_ALERT_FROM_PRIORITY]
+                ?? self::DEFAULT_ALERT_FROM_PRIORITY->value
+        ) ?? self::DEFAULT_ALERT_FROM_PRIORITY;
+    }
+}

--- a/webservice/src/Core/IntelPage/Port/PagerMessageRepository.php
+++ b/webservice/src/Core/IntelPage/Port/PagerMessageRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Port;
+
+use App\Core\IntelPage\Model\PagerMessage;
+
+interface PagerMessageRepository
+{
+    public function add(PagerMessage $pagerMessage): void;
+}

--- a/webservice/src/Core/IntelPage/Query/ChannelCapCodeById.php
+++ b/webservice/src/Core/IntelPage/Query/ChannelCapCodeById.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Query;
+
+use App\Core\Contracts\Bus\Query;
+use App\Core\IntelPage\Model\CapCode;
+
+/**
+ * @implements Query<CapCode|null>
+ */
+readonly class ChannelCapCodeById implements Query
+{
+    public function __construct(public string $channelId)
+    {
+    }
+}

--- a/webservice/src/Core/IntelPage/Query/PagerByRecipient.php
+++ b/webservice/src/Core/IntelPage/Query/PagerByRecipient.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\IntelPage\Query;
+
+use App\Core\Contracts\Bus\Query;
+use App\Core\IntelPage\Model\Pager;
+
+/**
+ * @implements Query<Pager|null>
+ */
+final readonly class PagerByRecipient implements Query
+{
+    public static function withId(string $id): self
+    {
+        return new self($id);
+    }
+
+    private function __construct(public string $recipientId)
+    {
+    }
+}

--- a/webservice/src/Core/TransportContract/Model/Message.php
+++ b/webservice/src/Core/TransportContract/Model/Message.php
@@ -8,15 +8,10 @@ use Symfony\Component\Uid\Ulid;
 
 /**
  * Contract for messages pushed to a transport, to keep the transport module low-level.
- *
- * @property Ulid     $messageId
- * @property string   $body
- * @property Priority $priority
  */
 interface Message
 {
-    // FOR PHP 8.4:
-    // public Ulid $messageId { get; }
-    // public string $body { get; }
-    // public Priority $priority { get; }
+    public Ulid $messageId { get; }
+    public string $body { get; }
+    public Priority $priority { get; }
 }

--- a/webservice/src/Core/TransportContract/Model/OutgoingMessageEvent.php
+++ b/webservice/src/Core/TransportContract/Model/OutgoingMessageEvent.php
@@ -30,6 +30,13 @@ readonly class OutgoingMessageEvent
         return new self($incomingMessageId, $outgoingMessageId, Instant::now(), OutgoingMessageStatus::QUEUED);
     }
 
+    public static function failedToQueue(
+        Ulid $incomingMessageId,
+        Ulid $outgoingMessageId,
+    ): self {
+        return new self($incomingMessageId, $outgoingMessageId, Instant::now(), OutgoingMessageStatus::ERROR);
+    }
+
     public static function transmitted(
         Ulid $incomingMessageId,
         Ulid $outgoingMessageId,

--- a/webservice/src/Core/TransportContract/Model/Priority.php
+++ b/webservice/src/Core/TransportContract/Model/Priority.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Core\TransportContract\Model;
 
 /*
- * Defines Priorities for the Messages
+ * Priorities that messages can be sent with
  */
 enum Priority: int
 {
@@ -14,4 +14,9 @@ enum Priority: int
     case DEFAULT = 30;
     case LOW = 20;
     case MIN = 10;
+
+    public function isHigherOrEqual(Priority $other): bool
+    {
+        return $this->value >= $other->value;
+    }
 }

--- a/webservice/src/Core/TransportContract/Port/TransportFactory/IntelPageTransportFactory.php
+++ b/webservice/src/Core/TransportContract/Port/TransportFactory/IntelPageTransportFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core\TransportContract\Port\TransportFactory;
+
+use App\Core\IntelPage\Application\IntelPageTransport;
+use App\Core\TransportContract\Model\SystemTransportConfig;
+
+interface IntelPageTransportFactory
+{
+    public function withSystemConfiguration(SystemTransportConfig $config): IntelPageTransport;
+}

--- a/webservice/src/Infrastructure/Persistence/DoctrineORM/Query/ChannelCapCodeByIdQueryHandler.php
+++ b/webservice/src/Infrastructure/Persistence/DoctrineORM/Query/ChannelCapCodeByIdQueryHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\DoctrineORM\Query;
+
+use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\Channel;
+use App\Core\IntelPage\Query\ChannelCapCodeById;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NoResultException;
+use Symfony\Component\Uid\Ulid;
+use function sprintf;
+
+final readonly class ChannelCapCodeByIdQueryHandler
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function __invoke(ChannelCapCodeById $query): ?CapCode
+    {
+        $dql = sprintf('SELECT c.capCode.code FROM %s c WHERE c.id = :channelId', Channel::class);
+        $parameters = ['channelId' => Ulid::fromString($query->channelId)->toRfc4122()];
+
+        $doctrineQuery = $this->em->createQuery($dql);
+        $doctrineQuery->setParameters($parameters);
+
+        try {
+            return CapCode::fromInt((int) $doctrineQuery->getSingleScalarResult());
+        } catch (NoResultException) {
+            return null;
+        }
+    }
+}

--- a/webservice/src/Infrastructure/Persistence/DoctrineORM/Query/PagerByRecipientQueryHandler.php
+++ b/webservice/src/Infrastructure/Persistence/DoctrineORM/Query/PagerByRecipientQueryHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\DoctrineORM\Query;
+
+use App\Core\IntelPage\Model\Pager;
+use App\Core\IntelPage\Query\PagerByRecipient;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Ulid;
+use function sprintf;
+
+final readonly class PagerByRecipientQueryHandler
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function __invoke(PagerByRecipient $query): ?Pager
+    {
+        $dql = sprintf('SELECT p FROM %s p JOIN p.carriedBy c WHERE c.id = :recipientId', Pager::class);
+        $parameters = ['recipientId' => Ulid::fromString($query->recipientId)->toRfc4122()];
+
+        $doctrineQuery = $this->em->createQuery($dql);
+        $doctrineQuery->setParameters($parameters);
+
+        // @phpstan-ignore return.type
+        return $doctrineQuery->getOneOrNullResult();
+    }
+}

--- a/webservice/tests/Core/IntelPage/Application/IntelPageTransportFactoryTest.php
+++ b/webservice/tests/Core/IntelPage/Application/IntelPageTransportFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\CommandBus;
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Bus\QueryBus;
+use App\Core\IntelPage\Application\IntelPageTransportFactory;
+use App\Core\TransportContract\Model\SystemTransportConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IntelPageTransportFactory::class)]
+#[Group('unit')]
+final class IntelPageTransportFactoryTest extends TestCase
+{
+    public function testCanInstantiateTransport(): void
+    {
+        // Arrange
+        $queryBus = self::createMock(QueryBus::class);
+        $commandBus = self::createMock(CommandBus::class);
+        $eventBus = self::createMock(EventBus::class);
+
+        $factory = new IntelPageTransportFactory(
+            $queryBus,
+            $commandBus,
+            $eventBus,
+        );
+
+        $systemTransportConfig = self::createMock(SystemTransportConfig::class);
+        $systemTransportConfig->method('getKey')->willReturn('some_key');
+
+        // Act
+        $transport = $factory->withSystemConfiguration($systemTransportConfig);
+
+        // Assert
+        self::assertSame('some_key', $transport->key());
+    }
+}

--- a/webservice/tests/Core/IntelPage/Application/IntelPageTransportTest.php
+++ b/webservice/tests/Core/IntelPage/Application/IntelPageTransportTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\CommandBus;
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Bus\QueryBus;
+use App\Core\IntelPage\Application\IntelPageTransport;
+use App\Core\IntelPage\Command\QueueMessage;
+use App\Core\IntelPage\Exception\IntelPageMessageTooLong;
+use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\Pager;
+use App\Core\IntelPage\Query\ChannelCapCodeById;
+use App\Core\IntelPage\Query\PagerByRecipient;
+use App\Core\TransportContract\Model\Message;
+use App\Core\TransportContract\Model\MessageRecipient;
+use App\Core\TransportContract\Model\OutgoingMessage;
+use App\Core\TransportContract\Model\OutgoingMessageEvent;
+use App\Core\TransportContract\Model\OutgoingMessageStatus;
+use App\Core\TransportContract\Model\Priority;
+use App\Core\TransportContract\Model\SystemTransportConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(IntelPageTransport::class)]
+#[Group('unit')]
+final class IntelPageTransportTest extends TestCase
+{
+    private function initTransport(?QueryBus $queryBus = null, ?CommandBus $commandBus = null, ?EventBus $eventBus = null): IntelPageTransport
+    {
+        $systemTransportConfigMock = self::createMock(SystemTransportConfig::class);
+        $systemTransportConfigMock->method('getKey')->willReturn('custom-key');
+        $queryBusMock = $queryBus ?? self::createMock(QueryBus::class);
+        $commandBusMock = $commandBus ?? self::createMock(CommandBus::class);
+        $eventBusMock = $eventBus ?? self::createMock(EventBus::class);
+
+        return new IntelPageTransport(
+            $systemTransportConfigMock,
+            $queryBusMock,
+            $commandBusMock,
+            $eventBusMock,
+        );
+    }
+
+    public function testKeyIsReturnedAsConfigured(): void
+    {
+        $transport = self::initTransport();
+        self::assertSame('custom-key', $transport->key());
+    }
+
+    public function testAlwaysAcceptsNewMessages(): void
+    {
+        $transport = self::initTransport();
+        self::assertTrue($transport->acceptsNewMessages());
+    }
+
+    public function testCanSendToReturnsFalseIfTransportWasNotConfigured(): void
+    {
+        $transport = self::initTransport();
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn(null);
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'A';
+            public Priority $priority = Priority::DEFAULT;
+        };
+
+        self::assertFalse($transport->canSendTo($messageRecipientMock, $messageMock));
+    }
+
+    public function testCanSendToWorksForChannels(): void
+    {
+        // Arrange
+        $queryBus = self::createMock(QueryBus::class);
+        $queryBus->method('get')->with(self::logicalAnd(self::isInstanceOf(ChannelCapCodeById::class), self::callback(fn (ChannelCapCodeById $value) => '01JT62N5PE9HBQTEZ1PPE6CJ4F' === $value->channelId)))->willReturn(CapCode::fromInt(222));
+
+        $transport = self::initTransport($queryBus);
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn(['channel' => '01JT62N5PE9HBQTEZ1PPE6CJ4F']);
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'qgpb2PoBt9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfi360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::HIGH;
+        };
+
+        // Assert & Act
+        self::assertTrue($transport->canSendTo($messageRecipientMock, $messageMock));
+    }
+
+    public function testCanSendToWorksForIndividuals(): void
+    {
+        // Arrange
+        $pagerMock = self::createMock(Pager::class);
+        $pagerMock->method('isActivated')->willReturn(true);
+        $pagerMock->method('individualAlertCap')->willReturn(CapCode::fromInt(999));
+        $pagerMock->method('individualNonAlertCap')->willReturn(CapCode::fromInt(111));
+
+        $queryBus = self::createMock(QueryBus::class);
+        $queryBus->method('get')->with(self::logicalAnd(self::isInstanceOf(PagerByRecipient::class), self::callback(fn (PagerByRecipient $value) => '01JT62N5PE9HBQTEZ1PPE6CJ4F' === $value->recipientId)))->willReturn($pagerMock);
+
+        $transport = self::initTransport($queryBus);
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn([]);
+        $messageRecipientMock->method('getId')->willReturn(Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F'));
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'qgpb2PoBt9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfi360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::HIGH;
+        };
+
+        // Assert & Act
+        self::assertTrue($transport->canSendTo($messageRecipientMock, $messageMock));
+    }
+
+    public function testCanSendToFailsWhenMessageIsTooLong(): void
+    {
+        self::expectException(IntelPageMessageTooLong::class);
+        self::expectExceptionMessage('The message was too long with 513 Bytes, the maximum allowed is 512.');
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'qgpb2PoBt9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfiL360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::HIGH;
+        };
+
+        $transport = self::initTransport();
+        $transport->canSendTo($messageRecipientMock, $messageMock);
+    }
+
+    public function testCanSendToPager(): void
+    {
+        // Expect
+        $pagerMock = self::createMock(Pager::class);
+        $pagerMock->method('isActivated')->willReturn(true);
+        $pagerMock->method('individualAlertCap')->willReturn(CapCode::fromInt(999));
+        $pagerMock->method('individualNonAlertCap')->willReturn(CapCode::fromInt(111));
+
+        $queryBus = self::createMock(QueryBus::class);
+        $queryBus->method('get')->with(self::logicalAnd(self::isInstanceOf(PagerByRecipient::class), self::callback(fn (PagerByRecipient $value) => '01JT62N5PE9HBQTEZ1PPE6CJ4F' === $value->recipientId)))->willReturn($pagerMock);
+
+        $commandBus = self::createMock(CommandBus::class);
+        $commandBus->expects(self::once())->method('do')->with(self::isInstanceOf(QueueMessage::class));
+
+        // Arrange
+        $transport = self::initTransport($queryBus, $commandBus);
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn([]);
+        $messageRecipientMock->method('getId')->willReturn(Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F'));
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'qgpb2PoBt9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfi360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::DEFAULT;
+        };
+
+        $outgoingMessage = OutgoingMessage::for($messageRecipientMock, $messageMock);
+
+        // Act
+        $transport->send($outgoingMessage);
+    }
+
+    public function testCanSendToChannel(): void
+    {
+        // Expect
+        $queryBus = self::createMock(QueryBus::class);
+        $queryBus->method('get')->with(self::logicalAnd(self::isInstanceOf(ChannelCapCodeById::class), self::callback(fn (ChannelCapCodeById $value) => '01JT62N5PE9HBQTEZ1PPE6CJ4F' === $value->channelId)))->willReturn(CapCode::fromInt(222));
+
+        $commandBus = self::createMock(CommandBus::class);
+        $commandBus->expects(self::once())->method('do')->with(self::isInstanceOf(QueueMessage::class));
+
+        // Arrange
+        $transport = self::initTransport($queryBus, $commandBus);
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn(['channel' => '01JT62N5PE9HBQTEZ1PPE6CJ4F']);
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 'qgpb2PoBt9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfi360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::DEFAULT;
+        };
+
+        $outgoingMessage = OutgoingMessage::for($messageRecipientMock, $messageMock);
+
+        // Act
+        $transport->send($outgoingMessage);
+    }
+
+    public function testSendCreaturesFailureEventWhenNoRecipientConfigIsMissing(): void
+    { // Expect
+        $eventBus = self::createMock(EventBus::class);
+        $eventBus->expects(self::once())->method('publish')->with(self::logicalAnd(
+            self::isInstanceOf(OutgoingMessageEvent::class),
+            self::callback(fn (OutgoingMessageEvent $value) => OutgoingMessageStatus::ERROR === $value->status)
+        ));
+
+        // Arrange
+        $transport = self::initTransport(eventBus: $eventBus);
+
+        $messageRecipientMock = self::createMock(MessageRecipient::class);
+        $messageRecipientMock->method('getTransportConfigurationFor')->with($transport)->willReturn(null);
+
+        $messageMock = new class implements Message {
+            public Ulid $messageId {
+                get {
+                    return Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+                }
+            }
+            public string $body = 't9hr6ZfUlMdvtnAibZHLvNZ0cHqqpRsuQu1n8agI50or83aq12ypFjfi360kwn3yq0YnSisYrTOwVyKxymJ4spvASR4nWvnjw5QeltBcA0eUbSlUv1ugkMPEMwvP8FTeuQXmoSWU2lOwN2BOTmiCGHtmOFUt5g6lGNxmblmpPEuHpqLVjTq5dlhv0B1lF1cokuLIaNpMQ2rr7KS6042SgQdT76BvevMLXwaMLAaKGOK2wz8xEVsLdEoV5GC1RTCrO8otd0Q8Srznlj1LLnFraRGrHPJNN5Va1eI8yOjR6FIJ0M1wnlqmXiRjDNbtcb2Q2WEKqe3kddkImoNSpbgHcRsVZZu2jZNVv2zqS1pbzGDIAjo1gMVm9KqyyonSNDuKPcvZpivSumYw4zZFnjg41JeMwVzlEscxqNDkNztRseCPUyEuJAClfe0LPn1Fz6nrQvVGPcjzMUhwKOAIOlRJtK03yptfr2G81GG3R9XbKy17PkQLJqk4BuNA';
+            public Priority $priority = Priority::DEFAULT;
+        };
+
+        $outgoingMessage = OutgoingMessage::for($messageRecipientMock, $messageMock);
+
+        // Act
+        $transport->send($outgoingMessage);
+    }
+}

--- a/webservice/tests/Core/IntelPage/Application/QueueMessageHandlerTest.php
+++ b/webservice/tests/Core/IntelPage/Application/QueueMessageHandlerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Core\IntelPage\Application;
+
+use App\Core\Contracts\Bus\EventBus;
+use App\Core\Contracts\Persistence\UnitOfWork;
+use App\Core\IntelPage\Application\QueueMessageHandler;
+use App\Core\IntelPage\Command\QueueMessage;
+use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\PagerMessage;
+use App\Core\IntelPage\Port\PagerMessageRepository;
+use App\Core\TransportContract\Model\OutgoingMessageEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(QueueMessageHandler::class), CoversClass(QueueMessage::class)]
+#[Group('unit')]
+final class QueueMessageHandlerTest extends TestCase
+{
+    public function testCanQueueMessage(): void
+    {
+        $id = Ulid::fromString(Ulid::generate());
+
+        $pagerMessageRepositoryMock = self::createMock(PagerMessageRepository::class);
+        $pagerMessageRepositoryMock->expects(self::once())->method('add')
+            ->with(self::callback(fn (PagerMessage $m) => (
+                'Hello World' === $m->getMessage()
+                && $m->getId()->equals($id)
+                && 1001 === $m->getCap()->getCode()
+            )));
+        // Pot. Improvement: Assert all properties if message are correct
+
+        $unitOfWorkMock = self::createMock(UnitOfWork::class);
+        $unitOfWorkMock->expects(self::once())->method('commit');
+
+        $eventBusMock = self::createMock(EventBus::class);
+        $eventBusMock->expects(self::once())->method('publish')->with(self::isInstanceOf(OutgoingMessageEvent::class));
+        // Pot. Improvement: Assert properties of event are correct
+
+        // sut = Subject Under Test i.e. the class we are testing
+        $sut = new QueueMessageHandler($pagerMessageRepositoryMock, $unitOfWorkMock, $eventBusMock);
+
+        $cmd = QueueMessage::with(
+            $id,
+            CapCode::fromInt(1001),
+            'Hello World',
+            1,
+            Ulid::fromString(Ulid::generate()),
+        );
+
+        // ACT
+        $sut->__invoke($cmd);
+    }
+}

--- a/webservice/tests/Core/IntelPage/Model/PagerMessageTest.php
+++ b/webservice/tests/Core/IntelPage/Model/PagerMessageTest.php
@@ -9,11 +9,13 @@ use App\Core\IntelPage\Model\PagerMessage;
 use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\DefaultClock;
 use Brick\DateTime\Instant;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Ulid;
 
+#[CoversClass(PagerMessage::class)]
 #[Group('unit')]
 final class PagerMessageTest extends TestCase
 {

--- a/webservice/tests/Core/IntelPage/Model/PagerTest.php
+++ b/webservice/tests/Core/IntelPage/Model/PagerTest.php
@@ -10,11 +10,14 @@ use App\Core\IntelPage\Model\ChannelCapAssignment;
 use App\Core\IntelPage\Model\IndividualCapAssignment;
 use App\Core\IntelPage\Model\Pager;
 use App\Core\IntelPage\Model\Slot;
+use App\Core\MessageRecipient\Model\AbstractMessageRecipient;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Ulid;
 
+#[CoversClass(Pager::class)]
 #[Group('unit')]
 final class PagerTest extends TestCase
 {
@@ -47,5 +50,74 @@ final class PagerTest extends TestCase
 
         $pager = new Pager(Ulid::fromString(Ulid::generate()), 'Pager 3', 3);
         $pager->clearSlot(Slot::fromInt(-1));
+    }
+
+    public function testIndividualAlertCap(): void
+    {
+        // Arrange
+        $pager = new Pager(Ulid::fromString(Ulid::generate()), 'Pager 1', 3);
+        $channel = new Channel(Ulid::fromString(Ulid::generate()), 'Channel 1', CapCode::fromInt(2));
+
+        self::assertNull($pager->individualAlertCap(), 'Gracefully returns null when no slots configured');
+
+        $pager
+            ->assignIndividualCap(Slot::fromInt(0), CapCode::fromInt(1), false, false)
+            ->assignIndividualCap(Slot::fromInt(1), CapCode::fromInt(2), false, true)
+            ->assignChannel(Slot::fromInt(2), $channel)
+            ->assignIndividualCap(Slot::fromInt(3), CapCode::fromInt(3), true, false)
+            ->assignChannel(Slot::fromInt(4), $channel)
+            ->assignIndividualCap(Slot::fromInt(5), CapCode::fromInt(4), true, true)
+            ->assignChannel(Slot::fromInt(6), $channel)
+            ->assignChannel(Slot::fromInt(7), $channel);
+
+        // Act & Assert
+        // @phpstan-ignore method.nonObject (no idea why phpstan shows this error)
+        self::assertEquals(3, $pager->individualAlertCap()?->getCode());
+    }
+
+    public function testIndividualNonAlertCap(): void
+    {
+        // Arrange
+        $pager = new Pager(Ulid::fromString(Ulid::generate()), 'Pager 1', 3);
+        $channel = new Channel(Ulid::fromString(Ulid::generate()), 'Channel 1', CapCode::fromInt(2));
+
+        self::assertNull($pager->individualNonAlertCap(), 'Gracefully returns null when no slots configured');
+
+        $pager
+            ->assignIndividualCap(Slot::fromInt(0), CapCode::fromInt(1), true, false)
+            ->assignIndividualCap(Slot::fromInt(1), CapCode::fromInt(2), true, true)
+            ->assignChannel(Slot::fromInt(2), $channel)
+            ->assignIndividualCap(Slot::fromInt(3), CapCode::fromInt(3), false, false)
+            ->assignChannel(Slot::fromInt(4), $channel)
+            ->assignIndividualCap(Slot::fromInt(5), CapCode::fromInt(4), false, true)
+            ->assignChannel(Slot::fromInt(6), $channel)
+            ->assignChannel(Slot::fromInt(7), $channel);
+
+        // Act & Assert
+        // @phpstan-ignore method.nonObject (no idea why phpstan shows this error)
+        self::assertEquals(3, $pager->individualNonAlertCap()?->getCode());
+    }
+
+    public function testIsActive(): void
+    {
+        $pager = new Pager(Ulid::fromString(Ulid::generate()), 'Pager 3', 3);
+
+        self::assertFalse($pager->isActivated(), 'Pager should be deactivated by default');
+        $pager->setActivated(true);
+        self::assertTrue($pager->isActivated(), 'Pager should be activated after activating it');
+        $pager->setActivated(false);
+        self::assertFalse($pager->isActivated(), 'Pager should be deactivated after deactivating it');
+    }
+
+    public function testCarriedBy(): void
+    {
+        $pager = new Pager(Ulid::fromString(Ulid::generate()), 'Pager 3', 3);
+        $recipient = $this->createMock(AbstractMessageRecipient::class);
+
+        self::assertNull($pager->getCarriedBy(), 'Pager is not carried by anyone when new');
+        $pager->setCarriedBy($recipient);
+        self::assertEquals($recipient, $pager->getCarriedBy(), 'Pager should be activated after activating it');
+        $pager->setCarriedBy(null);
+        self::assertNull($pager->getCarriedBy(), 'Pager not carried by after it was returned');
     }
 }

--- a/webservice/tests/Core/IntelPage/Model/RecipientConfigurationTest.php
+++ b/webservice/tests/Core/IntelPage/Model/RecipientConfigurationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Core\IntelPage\Model;
+
+use App\Core\IntelPage\Model\RecipientConfiguration;
+use App\Core\TransportContract\Model\Priority;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(RecipientConfiguration::class)]
+#[Group('unit')]
+final class RecipientConfigurationTest extends TestCase
+{
+    public function testRecipientCanBeConfiguredToSendToPager(): void
+    {
+        $recipientConfiguration = new RecipientConfiguration([
+            // leave empty, app will look for pager carried by the recipient
+        ]);
+
+        self::assertFalse($recipientConfiguration->hasChannelConfiguration());
+    }
+
+    public function testRecipientCanBeConfiguredToSendToChannel(): void
+    {
+        $id = Ulid::generate();
+
+        $recipientConfiguration = new RecipientConfiguration([
+            'channel' => $id,
+        ]);
+
+        self::assertTrue($recipientConfiguration->hasChannelConfiguration());
+        self::assertEquals($id, $recipientConfiguration->channelId());
+    }
+
+    /**
+     * @param array<string, int> $config
+     */
+    #[DataProvider('priorityConfigsProvider')]
+    public function testAlertFromPriority(array $config, Priority $result): void
+    {
+        $recipientConfiguration = new RecipientConfiguration($config);
+
+        self::assertEquals($result, $recipientConfiguration->alertFromPriority());
+    }
+
+    /**
+     * @return array<string, array<array<string, int>|Priority>>
+     */
+    public static function priorityConfigsProvider(): array
+    {
+        return [
+            'default' => [[], Priority::HIGH],
+            'lower' => [['alert_from_priority' => 30], Priority::DEFAULT],
+            'unknown' => [['alert_from_priority' => 35], Priority::HIGH],
+        ];
+    }
+}

--- a/webservice/tests/Core/IntelPage/Model/SlotTest.php
+++ b/webservice/tests/Core/IntelPage/Model/SlotTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace App\Tests\Core\IntelPage\Model;
 
-use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\Slot;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(CapCode::class)]
+#[CoversClass(Slot::class)]
 #[Group('unit')]
-final class CapCodeTest extends TestCase
+final class SlotTest extends TestCase
 {
     /**
      * @return array<string, list<int>>
@@ -21,8 +21,8 @@ final class CapCodeTest extends TestCase
     public static function validIntProvider(): array
     {
         return [
-            'lower bound' => [1],
-            'upper bound' => [9999],
+            'lower bound' => [0],
+            'upper bound' => [7],
         ];
     }
 
@@ -32,37 +32,36 @@ final class CapCodeTest extends TestCase
     public static function invalidIntProvider(): array
     {
         return [
-            'negatives' => [-1],
-            'lower bound' => [0],
-            'upper bound' => [10000],
+            'lower bound' => [-1],
+            'upper bound' => [8],
         ];
     }
 
     #[DataProvider('validIntProvider')]
     public function testCanBeCreatedByInt(int $testValue): void
     {
-        $cc = CapCode::fromInt($testValue);
-        self::assertTrue($testValue === $cc->getCode());
+        $cc = Slot::fromInt($testValue);
+        self::assertTrue($testValue === $cc->getSlot());
     }
 
     #[DataProvider('invalidIntProvider')]
-    public function testCreateInvalidCapCode(int $testValue): void
+    public function testCreateInvalidSlot(int $testValue): void
     {
         self::expectException(InvalidArgumentException::class);
-        CapCode::fromInt($testValue);
+        Slot::fromInt($testValue);
     }
 
     #[DataProvider('validIntProvider')]
     public function testCanBeCreatedFromString(int $testValue): void
     {
-        $cc = CapCode::fromString((string) $testValue);
-        self::assertTrue($testValue === $cc->getCode());
+        $cc = Slot::fromString((string) $testValue);
+        self::assertTrue($testValue === $cc->getSlot());
     }
 
     #[DataProvider('invalidIntProvider')]
-    public function testCreateInvalidCapCodeFromString(int $testValue): void
+    public function testCreateInvalidSlotFromString(int $testValue): void
     {
         self::expectException(InvalidArgumentException::class);
-        CapCode::fromString((string) $testValue);
+        Slot::fromString((string) $testValue);
     }
 }

--- a/webservice/tests/Core/TransportContract/Model/PriorityTest.php
+++ b/webservice/tests/Core/TransportContract/Model/PriorityTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Core\TransportContract\Model;
+
+use App\Core\TransportContract\Model\Priority;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Priority::class)]
+#[Group('unit')]
+final class PriorityTest extends TestCase
+{
+    /**
+     * @return array<string, array{Priority, Priority, bool}>
+     */
+    public static function provideHigherOrEqualsSamples(): array
+    {
+        return [
+            'high compared to low' => [Priority::HIGH, Priority::LOW, true],
+            'low compared to high' => [Priority::LOW, Priority::HIGH, false],
+            'urgent compared to high' => [Priority::URGENT, Priority::HIGH, true],
+            'min compared to low' => [Priority::MIN, Priority::LOW, false],
+            'default compared to low' => [Priority::DEFAULT, Priority::LOW, true],
+        ];
+    }
+
+    #[DataProvider('provideHigherOrEqualsSamples')]
+    public function testHigherOrEqualWorks(Priority $a, Priority $b, bool $expected): void
+    {
+        self::assertSame($expected, $a->isHigherOrEqual($b));
+    }
+}

--- a/webservice/tests/Infrastructure/Persistence/DoctrineORM/Query/ChannelCapCodeByIdQueryHandlerTest.php
+++ b/webservice/tests/Infrastructure/Persistence/DoctrineORM/Query/ChannelCapCodeByIdQueryHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Infrastructure\Persistence\DoctrineORM\Query;
+
+use App\Core\IntelPage\Model\CapCode;
+use App\Core\IntelPage\Model\Channel;
+use App\Core\IntelPage\Query\ChannelCapCodeById;
+use App\Infrastructure\Persistence\DoctrineORM\Query\ChannelCapCodeByIdQueryHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Ulid;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+#[CoversClass(ChannelCapCodeByIdQueryHandler::class)]
+#[Group('integration'), Group('integration.database')]
+final class ChannelCapCodeByIdQueryHandlerTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        $em->persist(new Channel(Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F'), 'Test Channel', CapCode::fromInt(222)));
+        $em->flush();
+        $em->clear();
+    }
+
+    public function testCanRetrieveCapCodeForChannel(): void
+    {
+        // Arrange
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $sut = new ChannelCapCodeByIdQueryHandler($em);
+
+        $query = new ChannelCapCodeById('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+
+        // Act
+        $result = $sut->__invoke($query);
+
+        // Assert
+        self::assertInstanceOf(CapCode::class, $result);
+        self::assertSame(222, $result->getCode());
+    }
+
+    public function testReturnsNullIfChannelNotFound(): void
+    {
+        // Arrange
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $sut = new ChannelCapCodeByIdQueryHandler($em);
+
+        $query = new ChannelCapCodeById('01JT61N5PE9HBQTEZ1PPE6CJ4F');
+
+        // Act
+        $result = $sut->__invoke($query);
+
+        // Assert
+        self::assertNull($result);
+    }
+}

--- a/webservice/tests/Infrastructure/Persistence/DoctrineORM/Query/PagerByRecipientQueryHandlerTest.php
+++ b/webservice/tests/Infrastructure/Persistence/DoctrineORM/Query/PagerByRecipientQueryHandlerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Infrastructure\Persistence\DoctrineORM\Query;
+
+use App\Core\IntelPage\Model\Pager;
+use App\Core\IntelPage\Query\PagerByRecipient;
+use App\Core\MessageRecipient\Model\Person;
+use App\Infrastructure\Persistence\DoctrineORM\Query\PagerByRecipientQueryHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Ulid;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+#[CoversClass(PagerByRecipientQueryHandler::class)]
+#[Group('integration'), Group('integration.database')]
+final class PagerByRecipientQueryHandlerTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        $carriedBy = new Person('test', Ulid::fromString('01JT62N5PE9HBQTEZ1PPE6CJ4F'));
+        $em->persist($carriedBy);
+        $pager = new Pager(Ulid::fromString('02JT62N5PE9HBQTEZ1PPE6CJ4F'), 'Test Channel', 1);
+        $pager->setCarriedBy($carriedBy);
+        $em->persist($pager);
+        $em->flush();
+        $em->clear();
+    }
+
+    public function testCanRetrievePagerForRecipient(): void
+    {
+        // Arrange
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $sut = new PagerByRecipientQueryHandler($em);
+
+        $query = PagerByRecipient::withId('01JT62N5PE9HBQTEZ1PPE6CJ4F');
+
+        // Act
+        $result = $sut->__invoke($query);
+
+        // Assert
+        self::assertInstanceOf(Pager::class, $result);
+        self::assertSame('02JT62N5PE9HBQTEZ1PPE6CJ4F', $result->getId()->toString());
+    }
+
+    public function testReturnsNullIfPagerNotFound(): void
+    {
+        // Arrange
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $sut = new PagerByRecipientQueryHandler($em);
+
+        $query = PagerByRecipient::withId('03JT62N5PE9HBQTEZ1PPE6CJ4D');
+
+        // Act
+        $result = $sut->__invoke($query);
+
+        // Assert
+        self::assertNull($result);
+    }
+}


### PR DESCRIPTION
Adds Transport interface implementation for the IntelPage module. Focus of this PR is the `IntelPageTransport` class, however the pull request includes everything needed from instantiating the transport to having a message queued.

Open Tasks:

- [x] Doctrine Query implementations @juliusstoerrle 
- [x] Resolve open todos
- [x] Complete test cases @Lukasswng 
- [x] Fix static analyser findings (have php 8.4 enabled first to simplify this) #73 
- [X] Requires #20 to be merged first.

